### PR TITLE
Frontend exercise - Mark email as opened

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-prettier": "^2.6.1",
     "eslint-plugin-react": "^7.9.1",
-    "prettier": "^1.13.5"
+    "prettier": "^1.13.5",
+    "react-test-renderer": "^16.4.2"
   }
 }

--- a/frontend/src/api/exercise.js
+++ b/frontend/src/api/exercise.js
@@ -1,0 +1,14 @@
+export const createAction = (actionType, associations, milliseconds) =>
+  fetch('/exercise/1/action/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      milliseconds,
+      action: {
+        type: actionType,
+        associations,
+      },
+    }),
+  });

--- a/frontend/src/api/exercise.spec.js
+++ b/frontend/src/api/exercise.spec.js
@@ -1,0 +1,32 @@
+import { createAction } from './exercise';
+
+describe('exercise API', () => {
+  describe('Given an action', () => {
+    const actionType = 'email_open';
+    const associations = { exerciseEmail: '1234' };
+    const timer = 1000;
+
+    describe('When the action is to be sent to the API', () => {
+      beforeEach(async () => {
+        window.fetch = jest.fn().mockImplementation(() => Promise.resolve());
+        await createAction(actionType, associations, timer);
+      });
+
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should send the data to create the action', () => {
+        const [endpoint, data] = window.fetch.mock.calls[0];
+        expect(endpoint).toBe('/exercise/1/action/');
+        expect(JSON.parse(data.body)).toEqual({
+          milliseconds: timer,
+          action: {
+            type: actionType,
+            associations,
+          },
+        });
+      });
+    });
+  });
+});

--- a/frontend/src/pages/Inbox/components/Email.js
+++ b/frontend/src/pages/Inbox/components/Email.js
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import styled, { css } from 'react-emotion';
 import format from 'date-fns/format';
 import Markdown from 'react-remarkable';
 
-import EmailCard from './EmailCard';
+import { markEmailAsOpened } from '../../../reducers/email';
 
+import EmailCard from './EmailCard';
 import QuickReply from './QuickReply';
 
 type Props = {
@@ -191,7 +193,12 @@ function EmailInfo({ email }) {
   );
 }
 
-export default class Email extends Component<Props> {
+class Email extends Component<Props> {
+  async componentDidMount() {
+    const { email, markEmailAsOpened } = this.props;
+    await markEmailAsOpened(email);
+  }
+
   render() {
     return (
       <div
@@ -226,3 +233,9 @@ export default class Email extends Component<Props> {
     );
   }
 }
+
+export const EmailComponent = Email;
+export default connect(
+  null,
+  { markEmailAsOpened }
+)(Email);

--- a/frontend/src/pages/Inbox/components/Email.spec.js
+++ b/frontend/src/pages/Inbox/components/Email.spec.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { EmailComponent as Email } from './Email';
+
+describe('<Email />', () => {
+  let props;
+
+  beforeEach(() => {
+    props = {
+      markEmailAsOpened: jest.fn().mockImplementation(() => Promise.resolve()),
+    };
+  });
+
+  describe('Given an email', () => {
+    beforeEach(() => {
+      props.email = {
+        subject: 'Welcome on board!',
+        from: {
+          name: 'Arther Ardent',
+          photoUrl: 'https://randomuser.me/api/portraits/men/32.jpg',
+          email: 'a.ardent@email.com',
+          role: 'MD',
+        },
+        id: 'fa59b235-184f-40ba-aae7-daaf48689d22',
+        timestamp: '2018-02-20:15:31.000Z',
+        body: `Hello,\n\nThank you for helping out with the conference organisation. Great to have you on board!\n\nWe are about to make the pay run and need your bank details...\n\nThanks, Arther`,
+      };
+    });
+
+    describe('When it is rendered', () => {
+      beforeEach(() => {
+        renderer.create(<Email {...props} />);
+      });
+
+      it('should call the `markEmailAsOpened` callback', () => {
+        expect(props.markEmailAsOpened).toHaveBeenCalledWith(props.email);
+      });
+    });
+  });
+});

--- a/frontend/src/reducers/email/email.spec.js
+++ b/frontend/src/reducers/email/email.spec.js
@@ -1,0 +1,40 @@
+import * as emailApi from '../../api/exercise';
+import { markEmailAsOpened } from './';
+
+describe('email state', () => {
+  beforeEach(() => {
+    emailApi.createAction = jest.fn(); // eslint-disable-line import/namespace
+  });
+
+  describe('Given an email', () => {
+    let email;
+
+    beforeEach(() => {
+      email = {
+        id: '345',
+      };
+    });
+
+    describe('When it is opened after 30 seconds', () => {
+      let dispatch;
+      let getState;
+      const timer = 30;
+
+      beforeEach(() => {
+        dispatch = jest.fn();
+        getState = jest
+          .fn()
+          .mockImplementation(() => ({ exercise: { timer } }));
+        markEmailAsOpened(email)(dispatch, getState);
+      });
+
+      it('should send the email open action to the api with the email associstation and time in milliseconds', () => {
+        expect(emailApi.createAction).toHaveBeenCalledWith(
+          'email_open',
+          { exerciseEmail: email.id },
+          timer * 1000
+        );
+      });
+    });
+  });
+});

--- a/frontend/src/reducers/email/index.js
+++ b/frontend/src/reducers/email/index.js
@@ -1,0 +1,44 @@
+// @flow
+import { createSelector } from 'reselect';
+import { createAction } from '../../api/exercise';
+
+const INITIAL_STATE = {};
+const MARK_EMAIL_AS_OPENED = 'email/MARK_EMAIL_AS_OPENED';
+
+export default function reducer(state = INITIAL_STATE, action = {}) {
+  switch (action.type) {
+    case MARK_EMAIL_AS_OPENED: {
+      return {
+        ...state,
+        opened: {
+          [action.payload]: true,
+        },
+      };
+    }
+
+    default: {
+      return state;
+    }
+  }
+}
+
+// Actions
+export function markEmailAsOpened({ id }) {
+  return async (dispatch, getState) => {
+    const { timer } = getState().exercise;
+    const associations = { exerciseEmail: id };
+    await createAction('email_open', associations, timer * 1000);
+    dispatch({
+      type: MARK_EMAIL_AS_OPENED,
+      payload: id,
+    });
+  };
+}
+
+// Selectors
+const exerciseSelector = state => state.exercise;
+
+export const getExerciseTimer = createSelector(
+  exerciseSelector,
+  exercise => exercise.timer
+);

--- a/frontend/src/reducers/index.js
+++ b/frontend/src/reducers/index.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux';
+import email from './email';
 import exercise from './exercise';
 import inbox from './inbox';
 
 const rootReducer = combineReducers({
+  email,
   exercise,
   inbox,
 });

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6060,6 +6060,10 @@ react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
 
+react-is@^16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
+
 react-redux@^5.0.7:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.7.tgz#0dc1076d9afb4670f993ffaef44b8f8c1155a4c8"
@@ -6144,6 +6148,15 @@ react-scripts@1.1.4:
     whatwg-fetch "2.0.3"
   optionalDependencies:
     fsevents "^1.1.3"
+
+react-test-renderer@^16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.4.2.tgz#4e03eca9359bb3210d4373f7547d1364218ef74e"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.4.2"
 
 react@^16.4.1:
   version "16.4.1"


### PR DESCRIPTION
### Assumptions

1. Emails are marked as opened regardless of scrolling position
2. Emails are marked as opened even if it has been done so before (although code has been implemented to note its opened status)

### Usage

When the email is rendered, it calls the `markEmailAsOpened` with the email object. The action gets the timer (in seconds) from `exercise` state, converts it to milliseconds and sends it with the action and email data to the API. 

### Run

```
$ yarn install
$ yarn start
```

### Test

```
$ yarn test
```

### Improvements

I prefer to decouple state management provider from the app as much as possible, and so instead of configuring the Redux store in the `<App>` component, it can be done in the root index file. This also means that instead of `dispatch`ing from the component, it should call the action instead, as the component shouldn't need to know about the store, just that there's a `tickTimer` prop that it can call.

The file/folder organisation can be improved, as there are child components within child components that are making files too long and thus making them harder to read and maintain.  Selectors can also be moved into separate files, but that's more of a personal preference.

Consistency of cases should be maintained, e.g. `file-manager` is kebab cased, whereas `Inbox` and `Accounts` are Pascal cased.

Variable/class names should also make sense, e.g. `ReplyButton.js` should export `ReplyButton` not `Button`; perhaps the currently named `ReplyButton` should be named `StyledButton`, and then `Button` can be named `ReplyButton`.

