### PR TITLE
GH-76 - exercise init endpoint

### DIFF
--- a/exercise/views.py
+++ b/exercise/views.py
@@ -1,6 +1,9 @@
-from rest_framework import viewsets, serializers
+from rest_framework import viewsets
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.response import Response
 
+from participant.models import Participant
 from .models import (
     Exercise,
     ExerciseEmail,
@@ -27,6 +30,17 @@ class ExerciseViewSet(viewsets.ModelViewSet):
         return [permission() for permission in permission_classes]
 
     http_method_names = ['get', 'head', 'options']
+
+    @action(methods=['get'], detail=True, permission_classes=[])
+    def init(self, request, *args, **kwargs):
+        exercise = self.get_object()
+        participant = Participant(exercise=exercise)
+        participant.save()
+        resp = {
+            'participant': str(participant.id),
+            'exercise': ExerciseSerializer(exercise).data
+        }
+        return Response(data=resp)
 
 
 class ExerciseEmailViewSet(viewsets.ModelViewSet):

--- a/phishtray/settings.py
+++ b/phishtray/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = 'w8w_cxqg6*d6#=#)4kfb-!&r72bp9s_l9x&@u&%@9a%s1bic(+'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['localhost', 'localhost:3000', 'localhost:9000']
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition
@@ -114,12 +114,12 @@ REST_FRAMEWORK = {
     # Camel case by default
     'DEFAULT_RENDERER_CLASSES': (
         'djangorestframework_camel_case.render.CamelCaseJSONRenderer',
-        # Any other renders
+        'rest_framework.renderers.BrowsableAPIRenderer'
     ),
 
     'DEFAULT_PARSER_CLASSES': (
         'djangorestframework_camel_case.parser.CamelCaseJSONParser',
-        # Any other parsers
+        'rest_framework.renderers.BrowsableAPIRenderer'
     ),
 
     # don't use underscores before numbers


### PR DESCRIPTION
- add exercise init endpoint so a participant ID can be fetched when the exercise is started at the FE
- restore browsable API view
- change allowed hosts back to all for local development