### PR TITLE
145 Email Deletion - per thread changes

### DIFF
--- a/frontend/src/pages/Inbox/components/Email.js
+++ b/frontend/src/pages/Inbox/components/Email.js
@@ -19,50 +19,10 @@ type Props = {
   markThreadAsDeleted: () => void,
 };
 
-const ActionLink = styled(Link)({
-  marginRight: 20,
-  textDecoration: 'none',
-  color: '#B8B8B8',
-  fontWeight: 'bold',
-  letterSpacing: '1.1px',
-});
-
 const Divider = styled('p')({
   borderBottom: '1px solid #CCC',
   margin: '20px 0px 20px',
 });
-
-function ActionLinkwithClick({
-  data,
-  title,
-  markThreadAsDeleted,
-  threadId,
-  remove,
-}) {
-  return (
-    <ActionLink
-      to={
-        remove
-          ? {
-              pathname: '/inbox',
-            }
-          : {}
-      }
-      onClick={() => {
-        logAction({
-          actionType: data.actionType,
-          participantId: data.participantId,
-          timeDelta: Date.now() - data.startTime,
-          emailId: data.emailId,
-          timestamp: new Date(),
-        });
-        remove && markThreadAsDeleted(threadId);
-      }}
-    >
-      {title}
-    </ActionLink>
-  );
-}
 
 const EmailField = styled('div')({
   color: '#B8B8B8',
@@ -82,55 +42,6 @@ const Paragraph = styled('p')({
   marginBottom: 20,
   fontSize: 20,
 });
-
-function EmailActions({ props }) {
-  const { markThreadAsDeleted, threadId, onReplyParams } = props;
-  return (
-    <div
-      className={css({
-        display: 'flex',
-        flexDirection: 'row',
-        justifyContent: 'flex-end',
-        marginTop: '20px',
-      })}
-    >
-      <ActionLinkwithClick
-        data={{
-          ...onReplyParams,
-          actionType: actionTypes.emailReply,
-        }}
-        title="Reply"
-      />
-      <ActionLinkwithClick
-        data={{
-          ...onReplyParams,
-          actionType: actionTypes.emailForward,
-        }}
-        title="Forward"
-      />
-      <ActionLinkwithClick
-        data={{
-          ...onReplyParams,
-          actionType: actionTypes.emailDelete,
-        }}
-        title="Delete"
-        markThreadAsDeleted={markThreadAsDeleted}
-        threadId={threadId}
-        remove
-      />
-      <ActionLinkwithClick
-        data={{
-          ...onReplyParams,
-          actionType: actionTypes.emailReport,
-        }}
-        title="Report"
-        markThreadAsDeleted={markThreadAsDeleted}
-        threadId={threadId}
-        remove
-      />
-    </div>
-  );
-}
 
 function EmailAttachments({ props }) {
   const { email, onReplyParams, addFile } = props;
@@ -313,7 +224,6 @@ const Email = (props: Props) => (
       padding: '0 40px',
     })}
   >
-    <EmailActions props={props} />
     <EmailInfo email={props.email} />
 
     <h3

--- a/frontend/src/pages/Inbox/components/EmailChain.js
+++ b/frontend/src/pages/Inbox/components/EmailChain.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
-import { css } from 'react-emotion';
+import styled, { css } from 'react-emotion';
+import { Link, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { Redirect } from 'react-router-dom';
 import {
   markThreadAsRead,
   markThreadAsDeleted,
@@ -9,8 +9,101 @@ import {
 import { getThread } from '../../../selectors/exerciseSelectors';
 import { showWebpage } from '../../../actions/uiActions';
 import { addFile } from '../../../actions/fileManagerActions';
-
+import actionTypes from '../../../config/actionTypes';
 import Email from './Email';
+import { logAction } from '../../../utils';
+
+const ActionLink = styled(Link)({
+  marginRight: 20,
+  textDecoration: 'none',
+  color: '#B8B8B8',
+  fontWeight: 'bold',
+  letterSpacing: '1.1px',
+});
+
+function ActionLinkwithClick({
+  data,
+  title,
+  markThreadAsDeleted,
+  threadId,
+  remove,
+}) {
+  return (
+    <ActionLink
+      to={
+        remove
+          ? {
+              pathname: '/inbox',
+            }
+          : {}
+      }
+      onClick={() => {
+        logAction({
+          actionType: data.actionType,
+          participantId: data.participantId,
+          timeDelta: Date.now() - data.startTime,
+          emailId: data.emailId,
+          timestamp: new Date(),
+        });
+        remove && markThreadAsDeleted(threadId);
+      }}
+    >
+      {title}
+    </ActionLink>
+  );
+}
+
+function EmailActions({ threadId, markThreadAsDeleted, onReplyParams }) {
+  return (
+    <div
+      className={css({
+        flexShrink: '0',
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'flex-end',
+        paddingTop: '20px',
+        paddingBottom: '20px',
+
+        background: 'white',
+      })}
+    >
+      <ActionLinkwithClick
+        data={{
+          ...onReplyParams,
+          actionType: actionTypes.emailReply,
+        }}
+        title="Reply"
+      />
+      <ActionLinkwithClick
+        data={{
+          ...onReplyParams,
+          actionType: actionTypes.emailForward,
+        }}
+        title="Forward"
+      />
+      <ActionLinkwithClick
+        data={{
+          ...onReplyParams,
+          actionType: actionTypes.emailDelete,
+        }}
+        title="Delete"
+        markThreadAsDeleted={markThreadAsDeleted}
+        threadId={threadId}
+        remove
+      />
+      <ActionLinkwithClick
+        data={{
+          ...onReplyParams,
+          actionType: actionTypes.emailReport,
+        }}
+        title="Report"
+        markThreadAsDeleted={markThreadAsDeleted}
+        threadId={threadId}
+        remove
+      />
+    </div>
+  );
+}
 
 export class EmailChain extends Component {
   componentDidMount() {
@@ -31,27 +124,55 @@ export class EmailChain extends Component {
   render() {
     const { thread } = this.props;
     return thread ? (
-      thread.emails.map(email => (
-        <Fragment key={email.id}>
-          <Email
-            email={email}
-            threadId={thread.id}
-            addFile={this.props.addFile}
-            markThreadAsDeleted={this.props.markThreadAsDeleted}
-            showWebpage={this.props.showWebpage}
-            onReplyParams={{
-              startTime: this.props.startTime,
-              participantId: this.props.participantId,
-              emailId: email.id,
-            }}
-          />
-          <hr
-            className={css({
-              width: '100%',
-            })}
-          />
-        </Fragment>
-      ))
+      <div
+        className={css({
+          height: '100%',
+          overflow: 'hidden',
+          // margin: '0px',
+          display: 'flex',
+          boxSizing: 'border-box',
+          flexDirection: 'column',
+        })}
+        key={thread.id}
+      >
+        <EmailActions
+          markThreadAsDeleted={this.props.markThreadAsDeleted}
+          threadId={thread.id}
+          onReplyParams={{
+            startTime: this.props.startTime,
+            participantId: this.props.participantId,
+            emailId: thread.id,
+          }}
+        />
+        <div
+          className={css({
+            flexGrow: 1,
+            overflowY: 'auto',
+          })}
+        >
+          {thread.emails.map(email => (
+            <Fragment key={email.id}>
+              <Email
+                email={email}
+                threadId={thread.id}
+                addFile={this.props.addFile}
+                markThreadAsDeleted={this.props.markThreadAsDeleted}
+                showWebpage={this.props.showWebpage}
+                onReplyParams={{
+                  startTime: this.props.startTime,
+                  participantId: this.props.participantId,
+                  emailId: email.id,
+                }}
+              />
+              <hr
+                className={css({
+                  width: '100%',
+                })}
+              />
+            </Fragment>
+          ))}
+        </div>
+      </div>
     ) : (
       <Redirect to="/inbox" />
     );

--- a/frontend/src/pages/Inbox/components/EmailChain.js
+++ b/frontend/src/pages/Inbox/components/EmailChain.js
@@ -59,11 +59,9 @@ function EmailActions({ threadId, markThreadAsDeleted, onReplyParams }) {
       className={css({
         flexShrink: '0',
         display: 'flex',
-        flexDirection: 'row',
         justifyContent: 'flex-end',
         paddingTop: '20px',
         paddingBottom: '20px',
-
         background: 'white',
       })}
     >
@@ -127,8 +125,6 @@ export class EmailChain extends Component {
       <div
         className={css({
           height: '100%',
-          overflow: 'hidden',
-          // margin: '0px',
           display: 'flex',
           boxSizing: 'border-box',
           flexDirection: 'column',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17146812/47091140-2ff06100-d21c-11e8-8950-9948a3fe8fd3.png)

I abstracted the action buttons to be a header per thread rather than a link of emails per row, so that you can delete/report/reply/forward to a thread, rather than to an individual email as that's not the intent