### PR TITLE
547 Open last email thread that was read

### DIFF
--- a/frontend/src/actions/exerciseActions.js
+++ b/frontend/src/actions/exerciseActions.js
@@ -37,6 +37,24 @@ export function markThreadAsDeleted(threadId: string) {
   };
 }
 
+export function markThreadAsActive(threadId: string) {
+  return {
+    type: 'exercise/MARK_THREAD_AS_ACTIVE',
+    payload: {
+      threadId,
+    },
+  };
+}
+
+export function markThreadAsInactive() {
+  return {
+    type: 'exercise/MARK_THREAD_AS_INACTIVE',
+    payload: {
+      threadId: '',
+    },
+  };
+}
+
 export const getExerciseData = (exerciseUuid: string) =>
   fetchAndDispatch(
     `/api/v1/exercises/${exerciseUuid}/init`,

--- a/frontend/src/pages/Inbox/components/EmailChain.js
+++ b/frontend/src/pages/Inbox/components/EmailChain.js
@@ -4,6 +4,7 @@ import { Link, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 import {
   markThreadAsRead,
+  markThreadAsInactive,
   markThreadAsDeleted,
   setSelectedReply,
 } from '../../../actions/exerciseActions';
@@ -26,6 +27,7 @@ function ActionLinkwithClick({
   data,
   title,
   markThreadAsDeleted,
+  markThreadAsInactive,
   threadId,
   remove,
 }) {
@@ -46,7 +48,7 @@ function ActionLinkwithClick({
           emailId: data.emailId,
           timestamp: new Date(),
         });
-        remove && markThreadAsDeleted(threadId);
+        remove && markThreadAsDeleted(threadId) && markThreadAsInactive();
       }}
     >
       {title}
@@ -54,7 +56,12 @@ function ActionLinkwithClick({
   );
 }
 
-function EmailActions({ threadId, markThreadAsDeleted, onReplyParams }) {
+function EmailActions({
+  threadId,
+  markThreadAsDeleted,
+  onReplyParams,
+  markThreadAsInactive,
+}) {
   return (
     <div
       className={css({
@@ -87,6 +94,7 @@ function EmailActions({ threadId, markThreadAsDeleted, onReplyParams }) {
         }}
         title="Delete"
         markThreadAsDeleted={markThreadAsDeleted}
+        markThreadAsInactive={markThreadAsInactive}
         threadId={threadId}
         remove
       />
@@ -97,6 +105,7 @@ function EmailActions({ threadId, markThreadAsDeleted, onReplyParams }) {
         }}
         title="Report"
         markThreadAsDeleted={markThreadAsDeleted}
+        markThreadAsInactive={markThreadAsInactive}
         threadId={threadId}
         remove
       />
@@ -134,6 +143,7 @@ export class EmailChain extends Component {
       >
         <EmailActions
           markThreadAsDeleted={this.props.markThreadAsDeleted}
+          markThreadAsInactive={this.props.markThreadAsInactive}
           threadId={thread.id}
           onReplyParams={{
             startTime: this.props.startTime,
@@ -185,6 +195,7 @@ export default connect(
   }),
   {
     markThreadAsRead,
+    markThreadAsInactive,
     showWebpage,
     addFile,
     markThreadAsDeleted,

--- a/frontend/src/pages/Inbox/components/EmailListItem.js
+++ b/frontend/src/pages/Inbox/components/EmailListItem.js
@@ -29,7 +29,11 @@ const Text = styled('div')(
   })
 );
 
-export default function EmailListItem({ email, onOpenParams }) {
+export default function EmailListItem({
+  email,
+  onOpenParams,
+  markThreadAsActive,
+}) {
   const { startTime, participantId } = onOpenParams;
   return (
     <Route path={`/inbox/${email.id}`}>
@@ -38,6 +42,7 @@ export default function EmailListItem({ email, onOpenParams }) {
           to={`/inbox/${email.id}`}
           className={css({ textDecoration: 'none', display: 'block' })}
           onClick={() => {
+            markThreadAsActive(email.id);
             logAction({
               participantId,
               actionType: actionTypes.emailOpen,

--- a/frontend/src/pages/Inbox/index.js
+++ b/frontend/src/pages/Inbox/index.js
@@ -3,7 +3,7 @@ import { Route } from 'react-router-dom';
 import styled, { css } from 'react-emotion';
 import { connect } from 'react-redux';
 import { InlineLoading } from 'carbon-components-react';
-
+import { markThreadAsActive } from '../../actions/exerciseActions';
 import {
   getThreads,
   getLastRefreshed,
@@ -33,6 +33,12 @@ const EmailContainer = styled('div')({
 });
 
 export class Inbox extends Component {
+  componentDidMount() {
+    const { match, activeThread, history } = this.props;
+    if (Object.keys(match.params).length === 0 && activeThread !== '') {
+      history.push(`/inbox/${activeThread}`);
+    }
+  }
   render() {
     const { match, threads } = this.props;
 
@@ -66,6 +72,7 @@ export class Inbox extends Component {
                 startTime: this.props.startTime,
                 participantId: this.props.participantId,
               }}
+              markThreadAsActive={this.props.markThreadAsActive}
             />
           ))}
         </EmailList>
@@ -83,6 +90,9 @@ export default connect(
     isLoaded: getLastRefreshed(state) !== null,
     startTime: state.exercise.startTime,
     participantId: state.exercise.participant,
+    activeThread: state.exercise.activeThread,
   }),
-  {}
+  {
+    markThreadAsActive,
+  }
 )(Inbox);

--- a/frontend/src/reducers/exerciseReducer.js
+++ b/frontend/src/reducers/exerciseReducer.js
@@ -6,6 +6,7 @@ const INITIAL_STATE: ExerciseState = {
   timer: 0, // exercise time elapsed in seconds
   startTime: 0, // Date.now() when form submitted,
   threads: [],
+  activeThread: '',
 };
 
 export default function reducer(
@@ -62,6 +63,18 @@ export default function reducer(
         );
         email.isReplied = true;
       });
+
+    case 'exercise/MARK_THREAD_AS_ACTIVE':
+      return {
+        ...state,
+        activeThread: action.payload.threadId,
+      };
+
+    case 'exercise/MARK_THREAD_AS_INACTIVE':
+      return {
+        ...state,
+        activeThread: action.payload.threadId,
+      };
 
     default:
       return state;


### PR DESCRIPTION
- Add feature where if a users clicks on an email, goes to another page, then goes to back to the inbox, the last email that was read will be displayed.
- Add two actions for making the email active or inactive.
- Whenever the user clicks on an email that makes it active. When the user goes off the inbox page and then back to it, it checks the state for an active email. If it has one then go to it.
- Whenever the user deletes an email that is active, it puts the activeThread state back to it's initial value.

![phishtray-emailz](https://user-images.githubusercontent.com/11047071/49373346-b215e580-f6f5-11e8-850e-54d4d1b93e29.gif)
