### PR TITLE
Host frontend and backend env vars

### DIFF
--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,7 +1,9 @@
 // @flow
 
-export const HOST_BACKEND = 'http://phishtray.local:9000';
-export const HOST_FRONTEND = 'http://phishtray.local:3000';
+export const HOST_BACKEND =
+  process.env.REACT_APP_HOST_BACKEND || 'http://phishtray.local:9000';
+export const HOST_FRONTEND =
+  process.env.REACT_APP_HOST_FRONTEND || 'http://phishtray.local:3000';
 
 export const fetchAndDispatch = (apiUrl: string, dispatchType: string) => (
   dispatch: *


### PR DESCRIPTION
- Make `HOST_BACKEND` and `HOST_FRONTEND` use env vars and default to phishtray.local when it's not set (when using locally)