### PR TITLE
Bump django version to 2.1.7 to address CVE-2019-3498

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dj-database-url==0.5.0
-Django==2.1.2
+Django==2.1.7
 django-cors-headers==2.4.0
 django-extensions==2.0.7
 django-filter==1.1.0


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20440288/53011541-870b7a00-3438-11e9-922b-1901a60a1cf9.png)
