### PR TITLE
NOTICKET - add profile entries to participant details on exercise-rep…

### DIFF
--- a/participant/serializer.py
+++ b/participant/serializer.py
@@ -56,10 +56,11 @@ class ParticipantSerializer(serializers.ModelSerializer):
 
 class ParticipantActionLogDownloadCSVSerializer(serializers.ModelSerializer):
     download_csv_url = serializers.SerializerMethodField()
+    profile = ParticipantProfileEntrySerializer(read_only=True, many=True)
 
     class Meta:
         model = Participant
-        fields = ('id', 'download_csv_url',)
+        fields = ('id', 'download_csv_url', 'profile')
 
     def get_download_csv_url(self, participant):
         req = self.context.get('request')

--- a/participant/tests/test_api.py
+++ b/participant/tests/test_api.py
@@ -14,9 +14,6 @@ from exercise.factories import DemographicsInfoFactory
 
 class ParticipantAPITests(PhishtrayAPIBaseTest):
 
-    def setUp(self):
-        super().setUp()
-
     def test_participant_list_block_public(self):
         """
         Non admin users should not be able to retrieve participant list.


### PR DESCRIPTION
Add profile entries to participant details on exercise-reports detail so admins can see questions and answers for given participant when downloading CSVs.

Example:
![image](https://user-images.githubusercontent.com/20440288/53127724-1610b300-355b-11e9-9932-2722221c8649.png)
