### PR TITLE
NOTICKET - add settings to be able to enable https redirect in case i…

### DIFF
--- a/phishtray/settings.py
+++ b/phishtray/settings.py
@@ -177,3 +177,5 @@ CORS_ALLOW_HEADERS = default_headers + (
 # Threshold for percentage number of emails that should have a reveal time set to zero.
 # The value should be in this range (0.0 - 1.0).
 REVEAL_TIME_ZERO_THRESHOLD = 0.1
+
+SECURE_SSL_REDIRECT = os.environ.get("SECURE_SSL_REDIRECT", False)


### PR DESCRIPTION
…t should be enforced, it can be activated by setting the SECURE_SSL_REDIRECT env var to True