### PR TITLE
add option to fake 0002 migration for users as those tables will like…

### DIFF
--- a/docker/local/Makefile
+++ b/docker/local/Makefile
@@ -56,8 +56,12 @@ django-migrate:
 django-showmigrations:
 	docker-compose exec django bash -c "python3.6 /usr/src/app/manage.py showmigrations"
 
-.PHONY: django-prepdb-multitenancy
-django-prepdb-multitenancy:
+.PHONY: django-fake-users-0001
+django-fake-users-0001:
 	docker-compose exec django bash -c "echo \"INSERT INTO django_migrations (app, name, applied) VALUES ('users', '0001_initial', CURRENT_TIMESTAMP);\" | python3.6 manage.py dbshell"
 	docker-compose exec django bash -c "echo \"UPDATE django_content_type SET app_label = 'users' WHERE app_label = 'auth' and model = 'user';\" | python3.6 manage.py dbshell"
+
+.PHONY: django-fake-users-0002
+django-fake-users-0002:
+	docker-compose exec django bash -c "echo \"INSERT INTO django_migrations (app, name, applied) VALUES ('users', '0002_auto_20190930_1718', CURRENT_TIMESTAMP);\" | python3.6 manage.py dbshell"
 # ==================================================


### PR DESCRIPTION
## UPDATED  Guide to How to Fix Custom User App Migration Issues (Local)
Custom user model was introduced to the project therefore existing databases are expected to raise errors during migration.

In case you need to keep your database please follow the guide below to fix the migration issues:
1. create a backup of your phishtray database (check settings/env var if in doubt which db to back up)
2. pull recent changes from this branch (or master once this branch is merged)
3. go to `cd docker/local` 
4. run `docker-compose down` then `docker-compose up -d --build` to rebuild the phishtray docker image
5. run `make django-fake-users-0001` to make the necessary DB tweaks prior to applying latest migrations
6. run `make django-migrate`
🐤 This should apply most migrations but you might see one of the errors below: 
    - `django.db.utils.ProgrammingError: (1146, "Table 'phishtray.auth_user' doesn't exist")`
    - `jango.db.utils.OperationalError: (1050, "Table 'auth_user_groups' already exists")`
6. run `make django-fake-users-0002` to get past the above error
7. run `make django-migrate` to apply the remaining migrations
8. run `make django-showmigrations` - all migrations should now be marked as applied
9. run `make django-test` and confirm that the tests can be run
10. run `make django-run` and verify that you can log in with the users you had in the DB prior to these steps
10. 👌 pat yourself on the back

PS: please note that this is only a method to fix the migration issues related to introducing the custom user, the steps above will not be able to resolve all migration issues so if in doubt please seek advice from one of the team members.