### PR TITLE
GH-221 Participant Behaviour & Actions

### DIFF
--- a/exercise/models.py
+++ b/exercise/models.py
@@ -209,6 +209,23 @@ class Exercise(PhishtrayBaseModel):
         default=False,
     )
 
+    @property
+    def phishing_emails(self):
+        return self.emails.filter(phish_type=EXERCISE_EMAIL_PHISH)
+
+    @property
+    def phishing_email_ids(self, uuid=False):
+        """
+        Returns an iterable with phishing email IDs.
+        :param uuid: BOOL - when True the function returns UUIDs
+        :return: MAP of the email ids as STRING
+        """
+        phishing_email_ids = self.phishing_emails.values_list('id', flat=True)
+        if uuid:
+            return phishing_email_ids
+        else:
+            return map(lambda x: str(x), phishing_email_ids)
+
     def set_email_reveal_times(self):
         emails = list(self.emails.all())
         if not emails:

--- a/participant/constants.py
+++ b/participant/constants.py
@@ -1,0 +1,19 @@
+# Action types are listed in frontend/src/config/actionTypes.js
+# TODO: move actiontypes to a config file that
+#       can be parsed/imported by both python and js
+
+NEGATIVE_ACTIONS = [
+    "email_attachment_download",
+    "email_forwarded",
+    "email_link_clicked",
+    "email_quick_reply",
+    "email_replied",
+]
+
+POSITIVE_ACTIONS = ["email_reported", "email_deleted"]
+
+
+class ParticipantBehaviour:
+    NEGATIVE = "negative"
+    NEUTRAL = "neutral"
+    POSITIVE = "positive"


### PR DESCRIPTION
### Introducing:
 - add helper methods to exercise so its convenient to fetch just the phishing emails
 - add helper method to participant so its easy to gather actions specific to a given email and judge user behaviour based on those actions

### Example Output
Method `Participant.phishing_email_behaviour_and_actions` requires an `email_id` and return a `tuple` of `(behaviour string, actions list)`

![image](https://user-images.githubusercontent.com/20440288/66207901-db9ff480-e6ab-11e9-9312-3b6ad9abdbdd.png)
