### PR TITLE
188 - Number Field Required

### DIFF
--- a/frontend/src/pages/Exercise/index.js
+++ b/frontend/src/pages/Exercise/index.js
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import {
   InlineLoading,
   Button,
-  NumberInput,
   TextInput,
   Form,
   Tile,

--- a/frontend/src/pages/Exercise/index.js
+++ b/frontend/src/pages/Exercise/index.js
@@ -200,7 +200,6 @@ export class Exercise extends Component<Props> {
                     <FormContainer key={item.id}>
                       <TextInput
                         type="number"
-                        min={16}
                         labelText={item.question}
                         id={`${item.id}`}
                         name={`${item.id}`}

--- a/frontend/src/pages/Exercise/index.js
+++ b/frontend/src/pages/Exercise/index.js
@@ -95,12 +95,6 @@ const FormContainer = styled('div')({
   paddingTop: '15px',
 });
 
-const Number = styled(NumberInput)`
-  .bx--number__controls {
-    visibility: hidden;
-  }
-`;
-
 type Props = {
   exercise: Object,
   match: Match,
@@ -205,16 +199,15 @@ export class Exercise extends Component<Props> {
                 case 0: // number
                   return (
                     <FormContainer key={item.id}>
-                      <Number
-                        className={css(`width: 100%`)}
-                        label={item.question}
-                        min={0}
+                      <TextInput
+                        type="number"
+                        min={16}
+                        labelText={item.question}
                         id={`${item.id}`}
                         name={`${item.id}`}
                         onChange={this.userInput}
                         onClick={this.userInput}
                         required={item.required}
-                        invalidText="Please input a number value"
                       />
                     </FormContainer>
                   );


### PR DESCRIPTION
- Carbon's Number Field is rubbish and auto adds the min value of the field. This means when the field is required, people can still skip entering a value as it already has the default value.

- Instead make the field a Carbon TextInput with a `type="number"` and pass the required prop AND a min value

<img width="452" alt="Screenshot 2019-11-05 at 15 24 09" src="https://user-images.githubusercontent.com/11047071/68221155-e8807280-ffe0-11e9-9749-b680c40f846f.png">
