### PR TITLE
339 - cache busting & email properties sync

### DIFF
--- a/exercise/apps.py
+++ b/exercise/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class ExerciseConfig(AppConfig):
     name = "exercise"
+
+    def ready(self):
+        import exercise.signals

--- a/exercise/signals.py
+++ b/exercise/signals.py
@@ -1,0 +1,9 @@
+from django.db.models.signals import m2m_changed
+from django.dispatch import receiver
+
+from exercise.models import Exercise
+
+
+@receiver(m2m_changed, sender=Exercise.emails.through)
+def sync_exercise_email_properties(sender, instance, **kwargs):
+    instance.sync_email_properties()

--- a/phishtray/base.py
+++ b/phishtray/base.py
@@ -5,6 +5,8 @@ from django.utils import timezone
 from django.db import models
 from django.db.models import QuerySet
 
+from utils.cache import flush_cache
+
 
 class SoftDeletionQuerySet(QuerySet):
     def delete(self):
@@ -58,3 +60,19 @@ class PhishtrayBaseModel(SoftDeletionModel):
 
     class Meta:
         abstract = True
+
+
+class CacheBusterMixin:
+    """
+    Use this mixin to flush the cache each time the instance is saved/deleted.
+    """
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        flush_cache()
+
+    # there's no need to override "delete"
+    # as that will save the object which already triggers a flush
+
+    def hard_delete(self):
+        super().hard_delete()
+        flush_cache()

--- a/phishtray/settings.py
+++ b/phishtray/settings.py
@@ -40,7 +40,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "corsheaders",
     "rest_framework",
-    "exercise",
+    "exercise.apps.ExerciseConfig",
     "participant",
     "frontend",
     "users",

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -1,0 +1,15 @@
+import logging
+
+from phishtray import settings
+from django.core.cache import cache
+
+
+logger = logging.getLogger(__name__)
+
+
+def flush_cache():
+    try:
+        assert settings.CACHES
+        cache.clear()
+    except AttributeError:
+        logger.exception("CACHES is not configured in settings.")


### PR DESCRIPTION
- set up signal to sync email properties when the set of emails allocated to an exercise change
- introduce mixin to flush cache after any instance that relates to exercises is saved