### PR TITLE
Revert "Bump django from 2.2.6 to 2.2.8 (#433)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coverage==4.5.4
 dj-database-url==0.5.0
-Django==2.2.8
+Django==2.2.6
 django-cors-headers==3.1.1
 django-extensions==2.2.3
 django-filter==2.2.0


### PR DESCRIPTION
This reverts commit 21f12f9fa0b71946f78f0363ee0999931e4f3252.
This django update breaks the exercise copy flow.
So a patch for django and exercise copy will need to be released together.