### PR TITLE
Fix IE bug on opening attachments on files tab

### DIFF
--- a/frontend/src/pages/FileManager/components/FileModal.js
+++ b/frontend/src/pages/FileManager/components/FileModal.js
@@ -26,7 +26,7 @@ const ModalContainer = styled('div')`
 `;
 
 const FileImage = styled('img')({
-  maxHeight: '100%',
+  maxHeight: 'inherit',
   maxWidth: '100%',
   paddingBottom: 5,
 });


### PR DESCRIPTION
<img width="1429" alt="Screenshot 2020-02-20 at 14 41 11" src="https://user-images.githubusercontent.com/37212039/74945176-303fd400-53ef-11ea-9d88-0a76abd51806.png">
<img width="1420" alt="Screenshot 2020-02-20 at 14 41 37" src="https://user-images.githubusercontent.com/37212039/74945188-359d1e80-53ef-11ea-9742-5d4dea9e9e6f.png">
