### PR TITLE
GH-450: Prolific ID in CSV and download CSV button in admin

### DIFF
--- a/exercise/views.py
+++ b/exercise/views.py
@@ -42,10 +42,7 @@ class ExerciseViewSet(viewsets.ModelViewSet):
     @method_decorator(cache_page(TWO_HOURS))
     def init(self, request, *args, **kwargs):
         exercise = self.get_object()
-        participant = Participant(
-            exercise=exercise,
-            organization=exercise.organization
-        )
+        participant = Participant(exercise=exercise, organization=exercise.organization)
         participant.save()
         resp = {
             "participant": str(participant.id),
@@ -122,7 +119,7 @@ class ExerciseReportViewSet(viewsets.ModelViewSet):
         serializer = ParticipantActionLogToCSVSerializer(participant)
         csv_data = serializer.data.get("csv")
 
-        file_name = "participant_{}.csv".format(participant_id)
+        file_name = "participant_{}_PID_{}.csv".format(participant_id, participant.pid)
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = 'attachment; filename="{}"'.format(file_name)
 

--- a/participant/models.py
+++ b/participant/models.py
@@ -116,6 +116,19 @@ class Participant(PhishtrayBaseModel):
         return participant_behaviour(actions), actions
 
     @property
+    def pid(self):
+        """
+        Returns Prolific ID or None
+        """
+        entry = self.profile.filter(
+            demographics_info__question__icontains="prolific id"
+        ).first()
+        if entry:
+            return entry.answer
+        else:
+            return None
+
+    @property
     def scores(self):
         exercise_replies = ExerciseEmailReply.objects.filter(
             exerciseemail__in=self.exercise.emails.all()

--- a/participant/serializer.py
+++ b/participant/serializer.py
@@ -169,6 +169,7 @@ class ParticipantActionLogToCSVSerializer(serializers.ModelSerializer):
             "entered_details_time": None,
             "submitted_details": None,
             "submitted_details_time": None,
+            "prolific_id": participant.pid,
         }
         csv_row_dicts = []
 

--- a/phishtray/settings.py
+++ b/phishtray/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "corsheaders",
     "rest_framework",
+    "inline_actions",
     "exercise.apps.ExerciseConfig",
     "participant",
     "frontend",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Django==2.2.6
 django-cors-headers==3.1.1
 django-extensions==2.2.3
 django-filter==2.2.0
+django-inline-actions==2.3.0
 djangorestframework==3.10.3
 djangorestframework-camel-case==1.1.1
 factory-boy==2.12.0


### PR DESCRIPTION
GH-450:
- add prolific id to CSV and file name
- add button to participants list view so email interaction data can be downloaded from django admin