### PR TITLE
No-Ticket Demographic questions bug

### DIFF
--- a/frontend/src/pages/Exercise/index.js
+++ b/frontend/src/pages/Exercise/index.js
@@ -114,6 +114,7 @@ function Exercise({ match, history }: Props) {
 
   const userInput = event => {
     setItem({
+      ...item,
       [event.target.id]: {
         id: event.target.name,
         value: event.target.value,


### PR DESCRIPTION
Fix issue where only one demographic question was being sent to api. This is because we are overwriting what answer is already in the state each time.