### PR TITLE
Bug - Multiple Participants being created

### DIFF
--- a/frontend/src/actions/exerciseActions.js
+++ b/frontend/src/actions/exerciseActions.js
@@ -71,6 +71,12 @@ export const getExerciseData = (exerciseUuid: string) =>
     'exercise/LOAD_DATA'
   );
 
+export function clearParticipantId() {
+  return {
+    type: 'exercise/CLEAR_PARTICIPANT_ID',
+  };
+}
+
 export function setSelectedReply(params: Object) {
   const { threadId, selectedReplyid, emailid } = params;
   return {

--- a/frontend/src/pages/Exercise/index.js
+++ b/frontend/src/pages/Exercise/index.js
@@ -18,6 +18,7 @@ import {
 import type { ExerciseState } from '../../types/exerciseTypes';
 
 import {
+  clearParticipantId,
   getExerciseData,
   startCountdown,
   tickTimer,
@@ -90,9 +91,15 @@ function Exercise({ match, history }: Props) {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    const { exerciseUuid } = match.params;
-    dispatch(getExerciseData(exerciseUuid));
-  }, [dispatch, match.params]);
+    dispatch(clearParticipantId());
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (!participantId) {
+      const { exerciseUuid } = match.params;
+      dispatch(getExerciseData(exerciseUuid));
+    }
+  }, [dispatch, match.params, participantId]);
 
   useEffect(() => {
     if (item && Object.keys(item).length === 0) {

--- a/frontend/src/reducers/exerciseReducer.js
+++ b/frontend/src/reducers/exerciseReducer.js
@@ -30,6 +30,13 @@ export default function reducer(
       };
     }
 
+    case 'exercise/CLEAR_PARTICIPANT_ID': {
+      return {
+        ...state,
+        participant: null,
+      };
+    }
+
     case 'exercise/MARK_THREAD_AS_READ': {
       return produce(state, draft => {
         const { threadId } = action.payload;

--- a/frontend/src/reducers/exerciseReducer.js
+++ b/frontend/src/reducers/exerciseReducer.js
@@ -8,6 +8,7 @@ const INITIAL_STATE: ExerciseState = {
   threads: [],
   activeThread: '',
   inlineNotification: null,
+  participant: null,
 };
 
 export default function reducer(


### PR DESCRIPTION
Multiple participant ids were being created because the use effect hook was doing an api call to create a participant when you went onto `/form`.

- Fixed it by clearing any participant id on mount from the beginning
- Only doing api call to get exercise (and new participant) if participant in redux = null